### PR TITLE
Use type hieararchy from AST for GlympseKit classes' heirarchy and protocols.

### DIFF
--- a/tools/objc/interface/header.tpl
+++ b/tools/objc/interface/header.tpl
@@ -6,9 +6,9 @@
 {% import 'macros.tpl' as macros %}
 
 {% if type.is_protocol %}
-@protocol {{ type.name.objc_name }}< NSObject >
+@protocol {{ type.name.objc_name }}{{ macros.protocol_heirarchy(package=package, type=type) }}
 {% else %}
-@interface {{ type.name.objc_name }} : {{ macros.base_class(package=package, type=type) }}
+@interface {{ type.name.objc_name }} : {{ macros.class_heirarchy(package=package, type=type) }}
 {% endif %}
 
 {% for method in type.body -%}

--- a/tools/objc/interface/macros.tpl
+++ b/tools/objc/interface/macros.tpl
@@ -1,11 +1,15 @@
-{% macro base_class(package, type) -%}
-{% if type.name.objc_name in package.hierarchy and package.hierarchy[type.name.objc_name].base %}
-{{ package.hierarchy[type.name.objc_name].base }}
-{% else %}
-GlyCommon
+{% macro protocol_heirarchy(package, type) -%}
+{%- if type.protocols %}
+< {{",".join(type.protocols) }} >
+{%- else %}
+< NSObject >
 {%- endif %}
-{%- if type.is_sink %}
-< GlyEventSink >
+{%- endmacro %}
+
+{% macro class_heirarchy(package, type) -%}
+{{ type.base_class -}}
+{%- if type.protocols %}
+< {{",".join(type.protocols) }} >
 {%- endif %}
 {%- endmacro %}
 


### PR DESCRIPTION
The generated wrapper now looks to the protocol list for GlyEventSink to
determine whether to apply the sink template. This can be made more
generic when we handle boilerplate for other protocols.

Unhandled protocols can be dealt with by exluding the protocl generation
and using an empty protocol definition. The protocol marker still has
some value.
