### PR TITLE
Adding params blob to config to make more things configurable.

### DIFF
--- a/tools/objc/base.py
+++ b/tools/objc/base.py
@@ -84,6 +84,7 @@ class BaseTranslator(object):
         if type in config.data["types"]:
             return config.data["types"][type]
         if type.startswith("G"):
+            cpp_namespace = config.data["params"]["cpp_namespace"]
             interface_name = type[1:]
             objc_type_name = "Gly{}".format(interface_name)
             if objc_type_name in config.data["undefined"]:
@@ -100,8 +101,8 @@ class BaseTranslator(object):
                     "objc_name": objc_type_name,
                     "objc_type": "id<{}>".format(objc_type_name),
                     "objc_arg_name": objc_type_name,
-                    "cpp_type": "Glympse::{}".format(type),
-                    "cpp_arg_type": "const Glympse::{}&".format(type),
+                    "cpp_type": "{}::{}".format(cpp_namespace, type),
+                    "cpp_arg_type": "const {}::{}&".format(cpp_namespace, type),
                     "native": False
                 }
             else:
@@ -120,9 +121,9 @@ class BaseTranslator(object):
                     "objc_name": objc_type_name,
                     "objc_type": objc_type,
                     "objc_arg_name": objc_type_name,
-                    "cpp_type": "Glympse::{}".format(type),
-                    "cpp_holder_type": "Glympse::Holder<Glympse::I{}>".format(interface_name),
-                    "cpp_holder_private_type": "Glympse::Holder<Glympse::I{}Private>".format(interface_name),
+                    "cpp_type": "{}::{}".format(cpp_namespace, type),
+                    "cpp_holder_type": "Glympse::Holder<{}::I{}>".format(cpp_namespace, interface_name),
+                    "cpp_holder_private_type": "Glympse::Holder<{}::I{}Private>".format(cpp_namespace, interface_name),
                     "cpp_arg_type": "const Glympse::{}&".format(type),
                     "native": False
                 }

--- a/tools/objc/base.py
+++ b/tools/objc/base.py
@@ -152,6 +152,8 @@ class BaseTranslator(object):
             for type in types:
                 satisfied = True
                 for dependency in type.extends:
+                    if not dependency:
+                        continue
                     name = dependency["objc_name"]
                     if name in info:
                         # We only care about types that are imported as part of the same package. If the dependency is

--- a/tools/objc/class/source.tpl
+++ b/tools/objc/class/source.tpl
@@ -18,15 +18,15 @@
 {{ macros.method_signature(method=item) }}
 {
 {% if item.return_type.native %}
-    return Glympse::{{ type.name.java_name }}::{{ item.name }}({{ macros.method_call_args(method=item) }});
+    return {{ type.name.cpp_type }}::{{ item.name }}({{ macros.method_call_args(method=item) }});
 {% else %}
-    return Glympse::ClassBinder::bind(Glympse::{{ type.name.java_name }}::{{ item.name }}({{ macros.method_call_args(method=item) }}));
+    return Glympse::ClassBinder::bind({{ type.name.cpp_type }}::{{ item.name }}({{ macros.method_call_args(method=item) }}));
 {% endif %}
 }
 {% else %}
 + ({{ item.type.objc_type }}){{ item.variable_declarators[0].variable.name }}
 {
-    return Glympse::{{ type.name.java_name }}::{{ item.variable_declarators[0].variable.name }};
+    return {{ type.name.cpp_type }}::{{ item.variable_declarators[0].variable.name }};
 }
 {% endif %}
 

--- a/tools/objc/cls.py
+++ b/tools/objc/cls.py
@@ -25,9 +25,11 @@ class ClassTranslator(base.BaseTranslator):
 
     def __process_type(self, config, package, type):
         # Format new type name
+        cpp_namespace = config.data["params"]["cpp_namespace"]
         objc_name = "Gly{}".format(type.name)
         type.name = {
             "java_name": type.name,
+            "cpp_type": "{}::{}".format(cpp_namespace, type.name),
             "objc_name": objc_name
         }
 

--- a/tools/objc/interface.py
+++ b/tools/objc/interface.py
@@ -16,7 +16,7 @@ class InterfaceTranslator(base.BaseTranslator):
         # Type properties
         type.is_protocol = type.name["objc_name"] in config.data["protocols"]
         type.base_class, type.protocols = InterfaceTranslator.__find_class_hierarchy(config, package, type)
-        type.is_sink = "GlyEventSink" in type.protocols
+        type.is_sink = config.data["params"]["sink"]["source"] in type.protocols
         type.has_private = type.name["objc_name"] in package["private"]
 
         # Interfaces
@@ -66,20 +66,20 @@ class InterfaceTranslator(base.BaseTranslator):
     @staticmethod
     def __find_class_hierarchy(config, package, type):
         base = "GlyCommon"
-
         name = type.name["objc_name"]
         info = package["types_info"]
         protocols = config.data["protocols"]
 
-        if name in info:
-            type = info[name]
-            dependency = []
+        if not name in info:
+            return base, []
 
-            if type.extends:
-                first = type.extends[0]["objc_name"]
-                if first not in protocols:
-                    base = first
+        type = info[name]
+        if not type.extends:
+            return base, []
 
-            interfaces = [ x["objc_name"] for x in type.extends if x["objc_name"] in protocols ]
+        first = type.extends[0]["objc_name"]
+        if first not in protocols:
+            base = first
+        interfaces = [ x["objc_name"] for x in type.extends if x["objc_name"] in protocols ]
 
         return base, interfaces

--- a/tools/objc/interface/sink.tpl
+++ b/tools/objc/interface/sink.tpl
@@ -1,11 +1,11 @@
-#pragma mark - GlyEventSink
+#pragma mark - {{ config.params.sink.source }}
 
-- (BOOL)addListener:(id<GlyEventListener>)listener
+- (BOOL)addListener:(id<{{ config.params.sink.listener }}>)listener
 {
     return [_commonSink addListener:listener];
 }
 
-- (BOOL)removeListener:(id<GlyEventListener>)listener
+- (BOOL)removeListener:(id<{{ config.params.sink.listener }}>)listener
 {
     return [_commonSink removeListener:listener];
 }

--- a/tools/objc/interface/source.tpl
+++ b/tools/objc/interface/source.tpl
@@ -17,7 +17,7 @@
     {{ type.name.cpp_holder_type }} _common;
 {% endif %}
 {% if type.is_sink %}
-    GlyCommonSink* _commonSink;
+    {{ config.params.sink.common }}* _commonSink;
 {% endif %}
 }
 @end
@@ -33,7 +33,7 @@
     {
         _common = object;
 {% if type.is_sink %}
-        _commonSink = [[GlyCommonSink alloc] initWithSink:object];
+        _commonSink = [[{{ config.params.sink.common }} alloc] initWithSink:object];
 {% endif %}
     }
     return self;


### PR DESCRIPTION
@corvino @adamhillglympse PTAL

Adding the following blob to java2objc config to allow wrapping other Glympse libraries (e.g. EnRoute API).

```
  "params": {
    "cpp_namespace": "Glympse",
    "sink": {
      "source": "GlyEventSink",
      "listener": "GlyEventListener",
      "common": "GlyCommonSink"
    }
  }
```
