### PR TITLE
We need to provide a mechanism to define types in the objc package he…

### DIFF
--- a/tools/objc/interface/package.tpl
+++ b/tools/objc/interface/package.tpl
@@ -4,6 +4,9 @@
 //
 //------------------------------------------------------------------------------
 
+{% for type in package.additional_types %}
+@class {{ type }};
+{% endfor %}
 {% for type in package.types %}
 {% if type.is_protocol %}
 @protocol
@@ -13,6 +16,9 @@
  {{ type.name.objc_name }};
 {% endfor %}
 
+{% for type in package.additional_types %}
+#import "{{ type }}.h"
+{% endfor %}
 {% for type in package.types %}
 #import "{{ type.name.objc_name }}.h"
 {% endfor %}


### PR DESCRIPTION
…ader that don't exist in java. This is required in En Route to correctly generate the GlyEnRouteApi.h file.